### PR TITLE
More CDN friendly PSI API cache-buster

### DIFF
--- a/lib/run-pagespeed.js
+++ b/lib/run-pagespeed.js
@@ -4,7 +4,10 @@ const baseUrl = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed';
 
 async function runPagespeed(urlString, strategy) {
     const url = new URL(urlString);
-    url.searchParams.append('pagespeed-nocache', Date.now());
+    if(!url.hash) {
+      // bust PSI cache but not your CDN's cache
+      url.hash = `#${Date.now().toString().substring(6)}`
+    }
     const queryOptions = {
       url: url.toString(),
       strategy: strategy || 'mobile',

--- a/tests/__snapshots__/run-pagespeed.test.js.snap
+++ b/tests/__snapshots__/run-pagespeed.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`run-pagespeed runPageSpeed calls Desktop API and returns Lighthouse result 1`] = `
 Array [
-  "https://www.googleapis.com/pagespeedonline/v5/runPagespeed/?url=https%3A%2F%2Fwww.google.com%2F%3Fpagespeed-nocache%3D1479427200000&strategy=desktop",
+  "https://www.googleapis.com/pagespeedonline/v5/runPagespeed/?url=https%3A%2F%2Fwww.google.com%2F%237200000&strategy=desktop",
   Object {
     "json": true,
   },
@@ -11,7 +11,7 @@ Array [
 
 exports[`run-pagespeed runPageSpeed calls Mobile API and returns Lighthouse result 1`] = `
 Array [
-  "https://www.googleapis.com/pagespeedonline/v5/runPagespeed/?url=https%3A%2F%2Fwww.google.com%2F%3Fpagespeed-nocache%3D1479427200000&strategy=mobile",
+  "https://www.googleapis.com/pagespeedonline/v5/runPagespeed/?url=https%3A%2F%2Fwww.google.com%2F%237200000&strategy=mobile",
   Object {
     "json": true,
   },


### PR DESCRIPTION
The `pagespeed-score` cli tries to bust the PSI API cache to get more accurate results based on multiple runs.

In the past a `pagespeed-nocache` query param was added to URLs under test to achieve this but that had the unfortunate side-effect of busting warmed CDN caches serving the URL under test.

Most CDNs though ignore the hash in the URL (e.g. `https://123.com/path#hash-here`) BUT the PSI API includes that as a cache key.

After this PR goes in: 
Given the URL under test has no hash then `pagespeed-score` appends a short cache-buster timestamp and that will bust the PSI API cache (but likely not your own CDN cache)

Given the URL under test has a hash then `pagespeed-score` would rather not bust the PSI API cache and this renders multiple runs pointless in these cases (as PSI will likely serve results from cache)